### PR TITLE
Make concurrency configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 const Coupon = require('./lib/Coupon');
 
-const coupon = new Coupon();
+const coupon = new Coupon(5);
 coupon.InitExport();

--- a/lib/Coupon.js
+++ b/lib/Coupon.js
@@ -3,10 +3,15 @@ const csv = require('fast-csv');
 const BigCommerce = require('./BC');
 
 class Coupon {
-    constructor(isConcurrent = false) {
+    constructor(rate = 1) {
         this.bc = BigCommerce;
-        this.isConcurrent = isConcurrent;
         this.Streams = {};
+        this.state = {
+            totalPages: 0,
+            queue: [],
+            rate: rate,
+            startTime: 0
+        };
     }
 
     CreateCSVFile() {
@@ -30,6 +35,7 @@ class Coupon {
     }
 
     InitExport() {
+        this.state.startTime = Date.now();
         this.Streams = this.InitExportStream();
         this.GetAllCoupons();
     }
@@ -51,61 +57,108 @@ class Coupon {
 
     GetAllCoupons() {
         this.CountPages()
-        .then(this.PrepareRequests.bind(this))
-        .then(async requests => {
-            try {
-                const couponPages = await Promise.all(requests);
-                return this.WriteEachResultToCSV(couponPages);
-            } catch(err) {
-                console.log(err)
-            }
-        });
+        .then(this.PrepareQueue.bind(this))
     }
 
-    PrepareRequests(pages) {
-        const complete = pages + 1;
-        const requestGroup = [];
-        // TODO: Set up limiting so that only X amount of pages are pushed to the returned requestGroup before another cycle
-        for (let page = 1; page < complete; page++) {
-            requestGroup.push(this.GetPage(page))
+    /**
+     * Create a new generator that increments 1 at a time until the total is reached
+     * @param {Number} total - The total number of iterations
+     */
+    SpawnGenerator(total) {
+        function* generator(total) {
+            for (let i = 0; i < total; i++) {
+                yield i;
+            }
         }
-        return requestGroup;
+
+        return generator(total);
+    }
+
+    /**
+     * Sets up the API request queue based on the total number of pages
+     * @param {Number} pages
+     */
+    PrepareQueue(pages) {
+        this.state.totalPages = pages;
+        for (let pageNumber = 1; pageNumber < pages + 1; pageNumber++) {
+            this.state.queue.push(pageNumber);
+        }
+        return this.SetupRequestBlock();
+    }
+
+    /**
+     * Create a block of page numbers from the queue to request over the API
+     */
+    SetupRequestBlock() {
+        const block = this.state.queue.splice(0, this.state.rate);
+        const start = block[0];
+        const end = block[block.length - 1] + 1;
+        console.log('Queue:', this.state.queue);
+        console.log('Page(s) being requested:', block);
+
+        const requestGroup = [];
+        for (let index = start; index < end; index++) {
+            requestGroup.push(this.GetPage(index))
+        }
+
+        if (block.length) {
+            return this.ExecuteAPIRequests(requestGroup);
+        } else {
+            const finishTime = Date.now();
+            console.log(`Time elapsed: ${Math.floor(finishTime - this.state.startTime) / 1000} seconds`);
+        }
+        
+    }
+
+    async ExecuteAPIRequests(requestGroup) {
+        try {
+            const couponPages = await Promise.all(requestGroup);
+            return this.WriteEachResultToCSV(couponPages);
+        } catch(err) {
+            console.log('Error executing requests: ',err)
+        }
     }
 
     /**
      * Iterate over the pages of responses and write them to a CSV
-     * @param {Object[]} pagesOfCoupons - Collection of arrays, each array containing a page of results from the API
+     * @param {Object[]} pagesOfCoupons - Collection of arrays, each array containing a page of coupons from the API
      */
     WriteEachResultToCSV(pagesOfCoupons) {
-       
-        // TODO: Set as different method or abstract into module
-        function* createGenerator(len){
-            for (let i = 0; i < len; i++) {
-                yield i
-            }
-        }
-        const pagesToIterate = pagesOfCoupons.length;
-        const generator = createGenerator(pagesToIterate);
+        const total = pagesOfCoupons.length;
+        const generator = this.SpawnGenerator(total);
 
         return this.CyclePages(generator, pagesOfCoupons);
     }
-
-    // Recursively called to go through each page, using generator to keep track of pages
+    /**
+     * Recursively called to write each page returned by API to a CSV file
+     * @param {Object} generator - A generator that increments 1 at a time
+     * @param {Object[]} pagesOfCoupons
+     */
     CyclePages(generator, pagesOfCoupons) {
         const cycle = generator.next();
-        if(!cycle.done) {
+
+        if (!cycle.done) {
             const currentCouponPage = cycle.value;
-            pagesOfCoupons[currentCouponPage].forEach(coupon => this.WriteAndPublishCSV(coupon));
-            this.CyclePages(generator, pagesOfCoupons);
+            let counter = 0;
+            pagesOfCoupons[currentCouponPage].forEach((coupon, _, page) => {
+                this.WriteToCSV(coupon);
+                counter++;
+                if (counter == page.length) {
+                    this.CyclePages(generator, pagesOfCoupons);
+                }
+            });
         } else {
-            console.log(`Export completed!\nFilename: ${this.Streams.filename}`);
+            this.SetupRequestBlock();
         }
     }
 
-    WriteAndPublishCSV(coupon) {
+    WriteToCSV(coupon) {
         this.Streams.csvStream.write(this.FormatExportContent(coupon));
     }
-
+    /**
+     * Takes a coupon returned from API and formats it for CSV. Object keys are used as CSV headers.
+     * @param {Object} coupon - A coupon returned from the API
+     */
     FormatExportContent(coupon) {
         return {
             'Coupon ID': parseInt(coupon['id']),


### PR DESCRIPTION
When creating a new Coupon class, a user can set the rate at which requests are fired off concurrently by passing an integer as an argument. If no rate is set, the app will default to 1 API request at a time.